### PR TITLE
Add support for using NSD

### DIFF
--- a/CardGames/CardGames/src/main/AndroidManifest.xml
+++ b/CardGames/CardGames/src/main/AndroidManifest.xml
@@ -117,7 +117,13 @@
             android:screenOrientation="sensorLandscape"
             android:theme="@style/Theme.CardGames" />
         <activity
-            android:name=".shared.activities.DeviceListActivity"
+            android:name=".shared.activities.JmDnsDeviceListActivity"
+            android:configChanges="orientation|keyboardHidden"
+            android:label="@string/title_device_list"
+            android:screenOrientation="sensorLandscape"
+            android:theme="@style/Theme.CardGames" />
+        <activity
+            android:name=".shared.activities.NsdDeviceListActivity"
             android:configChanges="orientation|keyboardHidden"
             android:label="@string/title_device_list"
             android:screenOrientation="sensorLandscape"

--- a/CardGames/CardGames/src/main/java/com/worthwhilegames/cardgames/player/activities/ConnectActivity.java
+++ b/CardGames/CardGames/src/main/java/com/worthwhilegames/cardgames/player/activities/ConnectActivity.java
@@ -6,10 +6,12 @@ import static com.worthwhilegames.cardgames.shared.Constants.KEY_PLAYER_NAME;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import android.app.Activity;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.os.Build;
 import android.os.Bundle;
 
 import com.worthwhilegames.cardgames.R;
@@ -18,6 +20,8 @@ import com.worthwhilegames.cardgames.shared.Constants;
 import com.worthwhilegames.cardgames.shared.GameFactory;
 import com.worthwhilegames.cardgames.shared.TextView;
 import com.worthwhilegames.cardgames.shared.activities.DeviceListActivity;
+import com.worthwhilegames.cardgames.shared.activities.JmDnsDeviceListActivity;
+import com.worthwhilegames.cardgames.shared.activities.NsdDeviceListActivity;
 import com.worthwhilegames.cardgames.shared.connection.ConnectionClient;
 import com.worthwhilegames.cardgames.shared.connection.ConnectionConstants;
 
@@ -80,7 +84,14 @@ public class ConnectActivity extends AdActivity {
                 finishActivity(GET_PLAYER_NAME);
 
                 // Show the device list
-                Intent showDeviceList = new Intent(ConnectActivity.this, DeviceListActivity.class);
+                Intent showDeviceList = null;
+
+                if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+                    showDeviceList = new Intent(ConnectActivity.this, NsdDeviceListActivity.class);
+                } else {
+                    showDeviceList = new Intent(ConnectActivity.this, JmDnsDeviceListActivity.class);
+                }
+
                 startActivityForResult(showDeviceList, DEVICE_LIST_RESULT);
             }
         }
@@ -121,7 +132,14 @@ public class ConnectActivity extends AdActivity {
         tv.setText(R.string.connecting);
 
         // Show the device list
-        Intent showDeviceList = new Intent(this, DeviceListActivity.class);
+        Intent showDeviceList = null;
+
+        if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+            showDeviceList = new Intent(ConnectActivity.this, NsdDeviceListActivity.class);
+        } else {
+            showDeviceList = new Intent(ConnectActivity.this, JmDnsDeviceListActivity.class);
+        }
+
         startActivityForResult(showDeviceList, DEVICE_LIST_RESULT);
 
         returnIntent = new Intent();

--- a/CardGames/CardGames/src/main/java/com/worthwhilegames/cardgames/player/activities/ConnectActivity.java
+++ b/CardGames/CardGames/src/main/java/com/worthwhilegames/cardgames/player/activities/ConnectActivity.java
@@ -1,29 +1,23 @@
 package com.worthwhilegames.cardgames.player.activities;
 
-import static com.worthwhilegames.cardgames.shared.Constants.GET_PLAYER_NAME;
-import static com.worthwhilegames.cardgames.shared.Constants.KEY_PLAYER_NAME;
-
-import org.json.JSONException;
-import org.json.JSONObject;
-
-import android.app.Activity;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.os.Build;
 import android.os.Bundle;
-
 import com.worthwhilegames.cardgames.R;
-import com.worthwhilegames.cardgames.shared.AdActivity;
-import com.worthwhilegames.cardgames.shared.Constants;
-import com.worthwhilegames.cardgames.shared.GameFactory;
-import com.worthwhilegames.cardgames.shared.TextView;
+import com.worthwhilegames.cardgames.shared.*;
 import com.worthwhilegames.cardgames.shared.activities.DeviceListActivity;
 import com.worthwhilegames.cardgames.shared.activities.JmDnsDeviceListActivity;
 import com.worthwhilegames.cardgames.shared.activities.NsdDeviceListActivity;
 import com.worthwhilegames.cardgames.shared.connection.ConnectionClient;
 import com.worthwhilegames.cardgames.shared.connection.ConnectionConstants;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import static com.worthwhilegames.cardgames.shared.Constants.GET_PLAYER_NAME;
+import static com.worthwhilegames.cardgames.shared.Constants.KEY_PLAYER_NAME;
 
 /**
  * The Activity that initiates the device list, and then
@@ -86,7 +80,7 @@ public class ConnectActivity extends AdActivity {
                 // Show the device list
                 Intent showDeviceList = null;
 
-                if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+                if (Util.shouldUseNsd && android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
                     showDeviceList = new Intent(ConnectActivity.this, NsdDeviceListActivity.class);
                 } else {
                     showDeviceList = new Intent(ConnectActivity.this, JmDnsDeviceListActivity.class);
@@ -134,7 +128,7 @@ public class ConnectActivity extends AdActivity {
         // Show the device list
         Intent showDeviceList = null;
 
-        if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+        if (Util.shouldUseNsd && android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
             showDeviceList = new Intent(ConnectActivity.this, NsdDeviceListActivity.class);
         } else {
             showDeviceList = new Intent(ConnectActivity.this, JmDnsDeviceListActivity.class);

--- a/CardGames/CardGames/src/main/java/com/worthwhilegames/cardgames/shared/Util.java
+++ b/CardGames/CardGames/src/main/java/com/worthwhilegames/cardgames/shared/Util.java
@@ -22,6 +22,12 @@ public class Util {
     public static final String TAG_GENERIC = Util.class.getName();
 
     /**
+     * Should we try and use Android's NSD library instead of
+     * the jmDns library we package with the app?
+     */
+    public static final boolean shouldUseNsd = true;
+
+    /**
      * Represents whether this device is acting as the gameboard
      */
     private static boolean isGameboard = false;

--- a/CardGames/CardGames/src/main/java/com/worthwhilegames/cardgames/shared/activities/DeviceListActivity.java
+++ b/CardGames/CardGames/src/main/java/com/worthwhilegames/cardgames/shared/activities/DeviceListActivity.java
@@ -124,6 +124,11 @@ public abstract class DeviceListActivity extends AdActivity {
 
         // Otherwise start discovering devices
         mDevicesArrayAdapter.clear();
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
         doDiscovery();
     }
 
@@ -135,6 +140,12 @@ public abstract class DeviceListActivity extends AdActivity {
         cancelDiscovery();
 
         super.onDestroy();
+    }
+
+    @Override
+    protected void onPause() {
+        cancelDiscovery();
+        super.onPause();
     }
 
     /**

--- a/CardGames/CardGames/src/main/java/com/worthwhilegames/cardgames/shared/activities/DeviceListActivity.java
+++ b/CardGames/CardGames/src/main/java/com/worthwhilegames/cardgames/shared/activities/DeviceListActivity.java
@@ -1,17 +1,10 @@
 package com.worthwhilegames.cardgames.shared.activities;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.jmdns.JmDNS;
-import javax.jmdns.ServiceEvent;
-import javax.jmdns.ServiceListener;
-
 import android.app.Activity;
 import android.content.Intent;
-import android.net.wifi.WifiManager;
-import android.net.wifi.WifiManager.MulticastLock;
 import android.os.Bundle;
 import android.os.Handler;
 import android.util.Log;
@@ -25,10 +18,9 @@ import android.widget.ListView;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 
-import com.worthwhilegames.cardgames.R;
 import com.worthwhilegames.cardgames.shared.AdActivity;
+import com.worthwhilegames.cardgames.R;
 import com.worthwhilegames.cardgames.shared.Util;
-import com.worthwhilegames.cardgames.shared.wifi.WifiConstants;
 
 /**
  * This Activity lists all devices that are discoverable, or paired and
@@ -42,7 +34,7 @@ import com.worthwhilegames.cardgames.shared.wifi.WifiConstants;
  *
  *         RESULT_CANCELLED - If no device was chosen
  */
-public class DeviceListActivity extends AdActivity implements ServiceListener {
+public abstract class DeviceListActivity extends AdActivity {
     /**
      * The Logcat Debug tag
      */
@@ -61,7 +53,7 @@ public class DeviceListActivity extends AdActivity implements ServiceListener {
     /**
      * A list of Device names that are currently added to the DeviceListAdapter
      */
-    private List<String> deviceNames = new ArrayList<String>();
+    protected List<String> deviceNames = new ArrayList<String>();
 
     /**
      * The TextView resource that contains the text "No Devices Found"
@@ -84,16 +76,6 @@ public class DeviceListActivity extends AdActivity implements ServiceListener {
     private ArrayAdapter<DeviceListItem> mDevicesArrayAdapter;
 
     /**
-     * The JmDNS instance used to find services
-     */
-    private JmDNS jmdns = null;
-
-    /**
-     * The Wifi Multicast Lock
-     */
-    private MulticastLock lock;
-
-    /**
      * A Handler used to run things on the UI thread
      */
     private Handler handler = new Handler();
@@ -101,7 +83,7 @@ public class DeviceListActivity extends AdActivity implements ServiceListener {
     /**
      * Represents whether we are cancelling the service
      */
-    private boolean isCancelling = false;
+    protected boolean isCancelling = false;
 
     /* (non-Javadoc)
      * @see android.app.Activity#onCreate(android.os.Bundle)
@@ -158,88 +140,19 @@ public class DeviceListActivity extends AdActivity implements ServiceListener {
     /**
      * Cancel the search for services
      */
-    private void cancelDiscovery() {
+    protected void cancelDiscovery() {
         if (Util.isDebugBuild()) {
             Log.d(TAG, "cancelDiscovery()");
         }
-
-        new Thread(new Runnable() {
-            @Override
-            public void run() {
-                synchronized (DeviceListActivity.this) {
-                    if (!isCancelling) {
-                        isCancelling = true;
-
-                        if (jmdns != null) {
-                            jmdns.removeServiceListener(WifiConstants.SERVICE_TYPE, DeviceListActivity.this);
-                            try {
-                                jmdns.close();
-                            } catch (IOException e) {
-                                e.printStackTrace();
-                            }
-                            jmdns = null;
-                        }
-
-                        lock.release();
-                    }
-                }
-            }
-        }).start();
-    }
-
-    @Override
-    public void serviceResolved(ServiceEvent ev) {
-        if (Util.isDebugBuild()) {
-            Log.d(TAG, "serviceResolved: " + deviceNames + " " + ev.getDNS().getHostName());
-        }
-
-        updateUi(ev);
-    }
-
-    @Override
-    public void serviceRemoved(ServiceEvent ev) {
-        if (Util.isDebugBuild()) {
-            Log.d(TAG, "Service removed: " + ev.getName());
-        }
-    }
-
-    @Override
-    public void serviceAdded(ServiceEvent event) {
-        if (Util.isDebugBuild()) {
-            Log.d(TAG, "serviceAdded");
-        }
-
-        // Required to force serviceResolved to be called again (after the first search)
-        jmdns.requestServiceInfo(event.getType(), event.getName(), 1);
     }
 
     /**
      * Start device discover with the BluetoothAdapter
      */
-    private void doDiscovery() {
+    protected void doDiscovery() {
         if (Util.isDebugBuild()) {
             Log.d(TAG, "doDiscovery()");
         }
-
-        // Create a Wifi Multicast Lock
-        WifiManager wifi = (WifiManager) getSystemService(android.content.Context.WIFI_SERVICE);
-        lock = wifi.createMulticastLock("CardGamesLock");
-        lock.setReferenceCounted(true);
-        lock.acquire();
-
-        // Create the JmDNS instance and start listening
-        new Thread(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    jmdns = JmDNS.create(Util.getLocalIpAddress());
-                    jmdns.addServiceListener(WifiConstants.SERVICE_TYPE, DeviceListActivity.this);
-                } catch (IOException e) {
-                    e.printStackTrace();
-                    return;
-                }
-            }
-        }).start();
 
         refreshDeviceListButton.setVisibility(View.INVISIBLE);
         deviceListProgress.setVisibility(View.VISIBLE);
@@ -283,21 +196,18 @@ public class DeviceListActivity extends AdActivity implements ServiceListener {
 
     /**
      * Update the UI based on the given event
-     * 
+     *
      * @param event the ServiceEvent
      */
-    private void updateUi(final ServiceEvent event) {
+    protected void updateUi(final DeviceListItem listItem, final String hostName) {
         handler.postDelayed(new Runnable() {
             @Override
             public void run() {
                 // If we have a host address, show it in the UI
-                if (event.getInfo().getHostAddresses().length > 0) {
-                    noDevicesFound.setVisibility(View.INVISIBLE);
-                    mDevicesArrayAdapter.add(new DeviceListItem(event.getName(), event.getInfo().getHostAddresses()[0], event.getInfo().getPort()));
-                    deviceNames.add(event.getDNS().getHostName());
-                }
+                noDevicesFound.setVisibility(View.INVISIBLE);
+                mDevicesArrayAdapter.add(listItem);
+                deviceNames.add(hostName);
             }
         }, 1);
     }
 }
-

--- a/CardGames/CardGames/src/main/java/com/worthwhilegames/cardgames/shared/activities/JmDnsDeviceListActivity.java
+++ b/CardGames/CardGames/src/main/java/com/worthwhilegames/cardgames/shared/activities/JmDnsDeviceListActivity.java
@@ -1,17 +1,15 @@
 package com.worthwhilegames.cardgames.shared.activities;
 
-import java.io.IOException;
+import android.net.wifi.WifiManager;
+import android.net.wifi.WifiManager.MulticastLock;
+import android.util.Log;
+import com.worthwhilegames.cardgames.shared.Util;
+import com.worthwhilegames.cardgames.shared.wifi.WifiConstants;
 
 import javax.jmdns.JmDNS;
 import javax.jmdns.ServiceEvent;
 import javax.jmdns.ServiceListener;
-
-import android.net.wifi.WifiManager;
-import android.net.wifi.WifiManager.MulticastLock;
-import android.util.Log;
-
-import com.worthwhilegames.cardgames.shared.Util;
-import com.worthwhilegames.cardgames.shared.wifi.WifiConstants;
+import java.io.IOException;
 
 public class JmDnsDeviceListActivity extends DeviceListActivity implements ServiceListener {
 
@@ -87,7 +85,11 @@ public class JmDnsDeviceListActivity extends DeviceListActivity implements Servi
         }
 
         if (ev.getInfo().getHostAddresses().length > 0) {
-            DeviceListItem item = new DeviceListItem(ev.getName(), ev.getInfo().getHostAddresses()[0], ev.getInfo().getPort());
+            String name = ev.getName();
+            if (name != null) {
+                name = name.replace("\\\\032", " ");
+            }
+            DeviceListItem item = new DeviceListItem(name, ev.getInfo().getHostAddresses()[0], ev.getInfo().getPort());
 
             updateUi(item, ev.getDNS().getHostName());
         }

--- a/CardGames/CardGames/src/main/java/com/worthwhilegames/cardgames/shared/activities/JmDnsDeviceListActivity.java
+++ b/CardGames/CardGames/src/main/java/com/worthwhilegames/cardgames/shared/activities/JmDnsDeviceListActivity.java
@@ -1,0 +1,113 @@
+package com.worthwhilegames.cardgames.shared.activities;
+
+import java.io.IOException;
+
+import javax.jmdns.JmDNS;
+import javax.jmdns.ServiceEvent;
+import javax.jmdns.ServiceListener;
+
+import android.net.wifi.WifiManager;
+import android.net.wifi.WifiManager.MulticastLock;
+import android.util.Log;
+
+import com.worthwhilegames.cardgames.shared.Util;
+import com.worthwhilegames.cardgames.shared.wifi.WifiConstants;
+
+public class JmDnsDeviceListActivity extends DeviceListActivity implements ServiceListener {
+
+    private static final String TAG = JmDnsDeviceListActivity.class.getName();
+
+    /**
+     * The JmDNS instance used to find services
+     */
+    private JmDNS jmdns = null;
+
+    /**
+     * The Wifi Multicast Lock
+     */
+    private MulticastLock lock;
+
+    @Override
+    protected void doDiscovery() {
+        super.doDiscovery();
+
+        // Create a Wifi Multicast Lock
+        WifiManager wifi = (WifiManager) getSystemService(android.content.Context.WIFI_SERVICE);
+        lock = wifi.createMulticastLock("CardGamesLock");
+        lock.setReferenceCounted(true);
+        lock.acquire();
+
+        // Create the JmDNS instance and start listening
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    jmdns = JmDNS.create(Util.getLocalIpAddress());
+                    jmdns.addServiceListener(WifiConstants.JMDNS_SERVICE_TYPE, JmDnsDeviceListActivity.this);
+                } catch (IOException e) {
+                    e.printStackTrace();
+                    return;
+                }
+            }
+        }).start();
+    }
+
+    @Override
+    protected void cancelDiscovery() {
+        super.cancelDiscovery();
+
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                synchronized (JmDnsDeviceListActivity.this) {
+                    if (!isCancelling) {
+                        isCancelling = true;
+
+                        if (jmdns != null) {
+                            jmdns.removeServiceListener(WifiConstants.JMDNS_SERVICE_TYPE, JmDnsDeviceListActivity.this);
+                            try {
+                                jmdns.close();
+                            } catch (IOException e) {
+                                e.printStackTrace();
+                            }
+                            jmdns = null;
+                        }
+
+                        lock.release();
+                    }
+                }
+            }
+        }).start();
+    }
+
+    @Override
+    public void serviceResolved(ServiceEvent ev) {
+        if (Util.isDebugBuild()) {
+            Log.d(TAG, "serviceResolved: " + deviceNames + " " + ev.getDNS().getHostName());
+        }
+
+        if (ev.getInfo().getHostAddresses().length > 0) {
+            DeviceListItem item = new DeviceListItem(ev.getName(), ev.getInfo().getHostAddresses()[0], ev.getInfo().getPort());
+
+            updateUi(item, ev.getDNS().getHostName());
+        }
+    }
+
+    @Override
+    public void serviceRemoved(ServiceEvent ev) {
+        if (Util.isDebugBuild()) {
+            Log.d(TAG, "Service removed: " + ev.getName());
+        }
+    }
+
+    @Override
+    public void serviceAdded(ServiceEvent event) {
+        if (Util.isDebugBuild()) {
+            Log.d(TAG, "serviceAdded");
+        }
+
+        // Required to force serviceResolved to be called again (after the first search)
+        jmdns.requestServiceInfo(event.getType(), event.getName(), 1);
+    }
+
+}

--- a/CardGames/CardGames/src/main/java/com/worthwhilegames/cardgames/shared/activities/NsdDeviceListActivity.java
+++ b/CardGames/CardGames/src/main/java/com/worthwhilegames/cardgames/shared/activities/NsdDeviceListActivity.java
@@ -1,0 +1,121 @@
+package com.worthwhilegames.cardgames.shared.activities;
+
+import java.net.InetAddress;
+
+import android.content.Context;
+import android.net.nsd.NsdManager;
+import android.net.nsd.NsdManager.DiscoveryListener;
+import android.net.nsd.NsdManager.ResolveListener;
+import android.net.nsd.NsdServiceInfo;
+import android.util.Log;
+
+import com.worthwhilegames.cardgames.shared.Util;
+import com.worthwhilegames.cardgames.shared.wifi.WifiConstants;
+
+public class NsdDeviceListActivity extends DeviceListActivity implements DiscoveryListener, ResolveListener {
+
+    private static final String TAG = NsdDeviceListActivity.class.getName();
+
+    /**
+     * The JmDNS instance used to find services
+     */
+    private NsdManager mNsdManager = null;
+
+    @Override
+    protected void doDiscovery() {
+        super.doDiscovery();
+
+        // Create the JmDNS instance and start listening
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                mNsdManager = (NsdManager) NsdDeviceListActivity.this.getSystemService(Context.NSD_SERVICE);
+                mNsdManager.discoverServices(WifiConstants.SERVICE_TYPE, NsdManager.PROTOCOL_DNS_SD, NsdDeviceListActivity.this);
+            }
+        }).start();
+    }
+
+    @Override
+    protected void cancelDiscovery() {
+        super.cancelDiscovery();
+
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                synchronized (NsdDeviceListActivity.this) {
+                    if (!isCancelling) {
+                        isCancelling = true;
+
+                        if (mNsdManager != null) {
+                            mNsdManager.stopServiceDiscovery(NsdDeviceListActivity.this);
+                        }
+                    }
+                }
+            }
+        }).start();
+    }
+
+
+    @Override
+    public void onDiscoveryStarted(String arg0) {
+        Log.d(TAG, "Service discovery started");
+    }
+
+    @Override
+    public void onDiscoveryStopped(String serviceType) {
+        Log.i(TAG, "Discovery stopped: " + serviceType);
+    }
+
+    @Override
+    public void onServiceFound(NsdServiceInfo service) {
+        // A service was found!  Do something with it.
+        Log.d(TAG, "Service discovery success" + service);
+        if (service.getServiceType().equals(WifiConstants.SERVICE_TYPE)) {
+            mNsdManager.resolveService(service, this);
+        }
+    }
+
+    @Override
+    public void onServiceLost(NsdServiceInfo service) {
+        // When the network service is no longer available.
+        // Internal bookkeeping code goes here.
+        Log.e(TAG, "service lost" + service);
+    }
+
+    @Override
+    public void onStartDiscoveryFailed(String arg0, int errorCode) {
+        Log.e(TAG, "Discovery failed: Error code:" + errorCode);
+        mNsdManager.stopServiceDiscovery(this);
+    }
+
+    @Override
+    public void onStopDiscoveryFailed(String arg0, int errorCode) {
+        Log.e(TAG, "Discovery failed: Error code:" + errorCode);
+        mNsdManager.stopServiceDiscovery(this);
+    }
+
+    @Override
+    public void onResolveFailed(NsdServiceInfo arg0, int errorCode) {
+        // Called when the resolve fails.  Use the error code to debug.
+        Log.e(TAG, "Resolve failed" + errorCode);
+    }
+
+    @Override
+    public void onServiceResolved(NsdServiceInfo serviceInfo) {
+        Log.e(TAG, "Resolve Succeeded. " + serviceInfo);
+
+        int port = serviceInfo.getPort();
+        InetAddress host = serviceInfo.getHost();
+
+        if (Util.isDebugBuild()) {
+            Log.d(TAG, "serviceResolved: " + deviceNames + " " + serviceInfo.getServiceName());
+        }
+
+        if (host != null) {
+            DeviceListItem item = new DeviceListItem(host.getHostName(), host.getHostAddress(), port);
+
+            updateUi(item, host.getHostName());
+        }
+    }
+
+}

--- a/CardGames/CardGames/src/main/java/com/worthwhilegames/cardgames/shared/activities/NsdDeviceListActivity.java
+++ b/CardGames/CardGames/src/main/java/com/worthwhilegames/cardgames/shared/activities/NsdDeviceListActivity.java
@@ -1,17 +1,18 @@
 package com.worthwhilegames.cardgames.shared.activities;
 
-import java.net.InetAddress;
-
+import android.annotation.TargetApi;
 import android.content.Context;
 import android.net.nsd.NsdManager;
 import android.net.nsd.NsdManager.DiscoveryListener;
 import android.net.nsd.NsdManager.ResolveListener;
 import android.net.nsd.NsdServiceInfo;
 import android.util.Log;
-
 import com.worthwhilegames.cardgames.shared.Util;
 import com.worthwhilegames.cardgames.shared.wifi.WifiConstants;
 
+import java.net.InetAddress;
+
+@TargetApi(16)
 public class NsdDeviceListActivity extends DeviceListActivity implements DiscoveryListener, ResolveListener {
 
     private static final String TAG = NsdDeviceListActivity.class.getName();
@@ -112,7 +113,7 @@ public class NsdDeviceListActivity extends DeviceListActivity implements Discove
         }
 
         if (host != null) {
-            DeviceListItem item = new DeviceListItem(host.getHostName(), host.getHostAddress(), port);
+            DeviceListItem item = new DeviceListItem(serviceInfo.getServiceName(), host.getHostAddress(), port);
 
             updateUi(item, host.getHostName());
         }

--- a/CardGames/CardGames/src/main/java/com/worthwhilegames/cardgames/shared/activities/NsdDeviceListActivity.java
+++ b/CardGames/CardGames/src/main/java/com/worthwhilegames/cardgames/shared/activities/NsdDeviceListActivity.java
@@ -22,18 +22,25 @@ public class NsdDeviceListActivity extends DeviceListActivity implements Discove
      */
     private NsdManager mNsdManager = null;
 
+    /**
+     * Whether we are discovering or not
+     */
+    private boolean isDiscovering = false;
+
     @Override
     protected void doDiscovery() {
         super.doDiscovery();
 
         // Create the JmDNS instance and start listening
-        new Thread(new Runnable() {
-            @Override
-            public void run() {
-                mNsdManager = (NsdManager) NsdDeviceListActivity.this.getSystemService(Context.NSD_SERVICE);
-                mNsdManager.discoverServices(WifiConstants.SERVICE_TYPE, NsdManager.PROTOCOL_DNS_SD, NsdDeviceListActivity.this);
-            }
-        }).start();
+        if (!isDiscovering) {
+            new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    mNsdManager = (NsdManager) NsdDeviceListActivity.this.getSystemService(Context.NSD_SERVICE);
+                    mNsdManager.discoverServices(WifiConstants.SERVICE_TYPE, NsdManager.PROTOCOL_DNS_SD, NsdDeviceListActivity.this);
+                }
+            }).start();
+        }
     }
 
     @Override
@@ -60,11 +67,13 @@ public class NsdDeviceListActivity extends DeviceListActivity implements Discove
     @Override
     public void onDiscoveryStarted(String arg0) {
         Log.d(TAG, "Service discovery started");
+        isDiscovering = true;
     }
 
     @Override
     public void onDiscoveryStopped(String serviceType) {
         Log.i(TAG, "Discovery stopped: " + serviceType);
+        isDiscovering = false;
     }
 
     @Override

--- a/CardGames/CardGames/src/main/java/com/worthwhilegames/cardgames/shared/activities/NsdDeviceListActivity.java
+++ b/CardGames/CardGames/src/main/java/com/worthwhilegames/cardgames/shared/activities/NsdDeviceListActivity.java
@@ -113,7 +113,11 @@ public class NsdDeviceListActivity extends DeviceListActivity implements Discove
         }
 
         if (host != null) {
-            DeviceListItem item = new DeviceListItem(serviceInfo.getServiceName(), host.getHostAddress(), port);
+            String name = serviceInfo.getServiceName();
+            if (name != null) {
+                name = name.replace("\\\\032", " ");
+            }
+            DeviceListItem item = new DeviceListItem(name, host.getHostAddress(), port);
 
             updateUi(item, host.getHostName());
         }

--- a/CardGames/CardGames/src/main/java/com/worthwhilegames/cardgames/shared/connection/IDnsWrapper.java
+++ b/CardGames/CardGames/src/main/java/com/worthwhilegames/cardgames/shared/connection/IDnsWrapper.java
@@ -1,9 +1,20 @@
 package com.worthwhilegames.cardgames.shared.connection;
 
+/**
+ * A wrapper around a multicast DNS service
+ *
+ * @author breber
+ */
 public interface IDnsWrapper {
 
+    /**
+     * Setup the broadcasting service
+     */
     void setup();
 
+    /**
+     * Tear down the broadcasting service
+     */
     void close();
 
 }

--- a/CardGames/CardGames/src/main/java/com/worthwhilegames/cardgames/shared/connection/IDnsWrapper.java
+++ b/CardGames/CardGames/src/main/java/com/worthwhilegames/cardgames/shared/connection/IDnsWrapper.java
@@ -1,0 +1,9 @@
+package com.worthwhilegames.cardgames.shared.connection;
+
+public interface IDnsWrapper {
+
+    void setup();
+
+    void close();
+
+}

--- a/CardGames/CardGames/src/main/java/com/worthwhilegames/cardgames/shared/connection/JmDnsWrapper.java
+++ b/CardGames/CardGames/src/main/java/com/worthwhilegames/cardgames/shared/connection/JmDnsWrapper.java
@@ -1,0 +1,73 @@
+package com.worthwhilegames.cardgames.shared.connection;
+
+import java.io.IOException;
+
+import javax.jmdns.JmDNS;
+import javax.jmdns.ServiceInfo;
+import javax.jmdns.impl.JmDNSImpl;
+
+import android.content.Context;
+import android.net.wifi.WifiManager;
+import android.net.wifi.WifiManager.MulticastLock;
+
+import com.worthwhilegames.cardgames.shared.GameFactory;
+import com.worthwhilegames.cardgames.shared.Util;
+import com.worthwhilegames.cardgames.shared.wifi.WifiConstants;
+
+public class JmDnsWrapper implements IDnsWrapper {
+
+    /**
+     * The Context
+     */
+    private Context mContext;
+
+    /**
+     * The JmDNS instance
+     */
+    private JmDNS jmdns = null;
+
+    /**
+     * The ServiceInfo we are broadcasting
+     */
+    private ServiceInfo serviceInfo;
+
+    /**
+     * The Wifi MulticastLock
+     */
+    private MulticastLock lock;
+
+    public JmDnsWrapper(Context context) {
+        mContext = context;
+        WifiManager wifi = (WifiManager) mContext.getSystemService(android.content.Context.WIFI_SERVICE);
+        lock = wifi.createMulticastLock("CardGamesLock");
+        lock.setReferenceCounted(true);
+        lock.acquire();
+    }
+
+    public void setup() {
+        try {
+            jmdns = new JmDNSImpl(Util.getLocalIpAddress(), "CardGames");
+            serviceInfo = ServiceInfo.create(WifiConstants.SERVICE_TYPE, GameFactory.getGameType(mContext) + ": " + android.os.Build.MODEL, GameFactory.getPortNumber(mContext), "Card Games for Android");
+            jmdns.registerService(serviceInfo);
+        } catch (IOException e) {
+            e.printStackTrace();
+            return;
+        }
+    }
+
+    public void close() {
+        if (jmdns != null) {
+            jmdns.unregisterAllServices();
+            try {
+                jmdns.close();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+            jmdns = null;
+        }
+
+        if (lock.isHeld()) {
+            lock.release();
+        }
+    }
+}

--- a/CardGames/CardGames/src/main/java/com/worthwhilegames/cardgames/shared/connection/JmDnsWrapper.java
+++ b/CardGames/CardGames/src/main/java/com/worthwhilegames/cardgames/shared/connection/JmDnsWrapper.java
@@ -1,18 +1,16 @@
 package com.worthwhilegames.cardgames.shared.connection;
 
-import java.io.IOException;
+import android.content.Context;
+import android.net.wifi.WifiManager;
+import android.net.wifi.WifiManager.MulticastLock;
+import com.worthwhilegames.cardgames.shared.GameFactory;
+import com.worthwhilegames.cardgames.shared.Util;
+import com.worthwhilegames.cardgames.shared.wifi.WifiConstants;
 
 import javax.jmdns.JmDNS;
 import javax.jmdns.ServiceInfo;
 import javax.jmdns.impl.JmDNSImpl;
-
-import android.content.Context;
-import android.net.wifi.WifiManager;
-import android.net.wifi.WifiManager.MulticastLock;
-
-import com.worthwhilegames.cardgames.shared.GameFactory;
-import com.worthwhilegames.cardgames.shared.Util;
-import com.worthwhilegames.cardgames.shared.wifi.WifiConstants;
+import java.io.IOException;
 
 public class JmDnsWrapper implements IDnsWrapper {
 
@@ -47,7 +45,7 @@ public class JmDnsWrapper implements IDnsWrapper {
     public void setup() {
         try {
             jmdns = new JmDNSImpl(Util.getLocalIpAddress(), "CardGames");
-            serviceInfo = ServiceInfo.create(WifiConstants.SERVICE_TYPE, GameFactory.getGameType(mContext) + ": " + android.os.Build.MODEL, GameFactory.getPortNumber(mContext), "Card Games for Android");
+            serviceInfo = ServiceInfo.create(WifiConstants.JMDNS_SERVICE_TYPE, GameFactory.getGameType(mContext) + ": " + android.os.Build.MODEL, GameFactory.getPortNumber(mContext), "Card Games for Android");
             jmdns.registerService(serviceInfo);
         } catch (IOException e) {
             e.printStackTrace();

--- a/CardGames/CardGames/src/main/java/com/worthwhilegames/cardgames/shared/connection/NsdWrapper.java
+++ b/CardGames/CardGames/src/main/java/com/worthwhilegames/cardgames/shared/connection/NsdWrapper.java
@@ -1,5 +1,6 @@
 package com.worthwhilegames.cardgames.shared.connection;
 
+import android.annotation.TargetApi;
 import android.content.Context;
 import android.net.nsd.NsdManager;
 import android.net.nsd.NsdManager.RegistrationListener;
@@ -9,6 +10,7 @@ import android.util.Log;
 import com.worthwhilegames.cardgames.shared.GameFactory;
 import com.worthwhilegames.cardgames.shared.wifi.WifiConstants;
 
+@TargetApi(16)
 public class NsdWrapper implements IDnsWrapper, RegistrationListener {
 
     private static final String TAG = NsdWrapper.class.getName();

--- a/CardGames/CardGames/src/main/java/com/worthwhilegames/cardgames/shared/connection/NsdWrapper.java
+++ b/CardGames/CardGames/src/main/java/com/worthwhilegames/cardgames/shared/connection/NsdWrapper.java
@@ -1,0 +1,75 @@
+package com.worthwhilegames.cardgames.shared.connection;
+
+import android.content.Context;
+import android.net.nsd.NsdManager;
+import android.net.nsd.NsdManager.RegistrationListener;
+import android.net.nsd.NsdServiceInfo;
+import android.util.Log;
+
+import com.worthwhilegames.cardgames.shared.GameFactory;
+import com.worthwhilegames.cardgames.shared.wifi.WifiConstants;
+
+public class NsdWrapper implements IDnsWrapper, RegistrationListener {
+
+    private static final String TAG = NsdWrapper.class.getName();
+
+    /**
+     * The Context
+     */
+    private Context mContext;
+
+    /**
+     * The JmDNS instance
+     */
+    private NsdManager mNsdManager = null;
+
+    /**
+     * The ServiceInfo we are broadcasting
+     */
+    private NsdServiceInfo serviceInfo;
+
+    public NsdWrapper(Context context) {
+        mContext = context;
+    }
+
+    @Override
+    public void setup() {
+        serviceInfo  = new NsdServiceInfo();
+        serviceInfo.setServiceName(GameFactory.getGameType(mContext) + ": (NSD) " + android.os.Build.MODEL);
+        serviceInfo.setPort(GameFactory.getPortNumber(mContext));
+        serviceInfo.setServiceType(WifiConstants.SERVICE_TYPE);
+
+        mNsdManager = (NsdManager) mContext.getSystemService(Context.NSD_SERVICE);
+
+        mNsdManager.registerService(serviceInfo, NsdManager.PROTOCOL_DNS_SD, this);
+    }
+
+    @Override
+    public void close() {
+        if (mNsdManager != null) {
+            mNsdManager.unregisterService(this);
+
+            mNsdManager = null;
+        }
+    }
+
+    @Override
+    public void onRegistrationFailed(NsdServiceInfo arg0, int arg1) {
+        Log.e(TAG, "registration failed: " + arg0.getServiceName() + " " + arg1);
+    }
+
+    @Override
+    public void onServiceRegistered(NsdServiceInfo arg0) {
+        Log.e(TAG, "service registered: " + arg0.getServiceName());
+    }
+
+    @Override
+    public void onServiceUnregistered(NsdServiceInfo arg0) {
+        Log.e(TAG, "service unregistered: " + arg0.getServiceName());
+    }
+
+    @Override
+    public void onUnregistrationFailed(NsdServiceInfo arg0, int arg1) {
+        Log.e(TAG, "unregistration failed: " + arg0.getServiceName() + " " + arg1);
+    }
+}

--- a/CardGames/CardGames/src/main/java/com/worthwhilegames/cardgames/shared/wifi/WifiConstants.java
+++ b/CardGames/CardGames/src/main/java/com/worthwhilegames/cardgames/shared/wifi/WifiConstants.java
@@ -14,6 +14,8 @@ public class WifiConstants {
     /**
      * The Bonjour Service Type to use for this app
      */
-    public static final String SERVICE_TYPE = "_cardgames._tcp.local.";
+    public static final String SERVICE_TYPE = "_cardgames._tcp.";
+
+    public static final String JMDNS_SERVICE_TYPE = SERVICE_TYPE + "local.";
 
 }

--- a/CardGames/CardGames/src/main/java/com/worthwhilegames/cardgames/shared/wifi/WifiServerSocket.java
+++ b/CardGames/CardGames/src/main/java/com/worthwhilegames/cardgames/shared/wifi/WifiServerSocket.java
@@ -27,7 +27,7 @@ public class WifiServerSocket implements IServerSocket {
      * Create a new WifiServerSocket
      */
     public WifiServerSocket(Context ctx) {
-        if (false && android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+        if (Util.shouldUseNsd && android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
             dnsWrapper = new NsdWrapper(ctx);
         } else {
             dnsWrapper = new JmDnsWrapper(ctx);

--- a/CardGames/CardGames/src/main/java/com/worthwhilegames/cardgames/shared/wifi/WifiServerSocket.java
+++ b/CardGames/CardGames/src/main/java/com/worthwhilegames/cardgames/shared/wifi/WifiServerSocket.java
@@ -1,17 +1,12 @@
 package com.worthwhilegames.cardgames.shared.wifi;
 
-import java.io.IOException;
-
 import android.content.Context;
 import android.os.Build;
-
 import com.worthwhilegames.cardgames.shared.GameFactory;
 import com.worthwhilegames.cardgames.shared.Util;
-import com.worthwhilegames.cardgames.shared.connection.IDnsWrapper;
-import com.worthwhilegames.cardgames.shared.connection.IServerSocket;
-import com.worthwhilegames.cardgames.shared.connection.ISocket;
-import com.worthwhilegames.cardgames.shared.connection.JmDnsWrapper;
-import com.worthwhilegames.cardgames.shared.connection.NsdWrapper;
+import com.worthwhilegames.cardgames.shared.connection.*;
+
+import java.io.IOException;
 
 /**
  * The Wifi implementation of a ServerSocket
@@ -32,7 +27,7 @@ public class WifiServerSocket implements IServerSocket {
      * Create a new WifiServerSocket
      */
     public WifiServerSocket(Context ctx) {
-        if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+        if (false && android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
             dnsWrapper = new NsdWrapper(ctx);
         } else {
             dnsWrapper = new JmDnsWrapper(ctx);


### PR DESCRIPTION
Since ICS, Android has had built-in support for multicast DNS, which means for newer devices, we don't need to use jmDNS anymore for automatic discovery of local devices. 
